### PR TITLE
Updated csproj with qwindows.dll copy

### DIFF
--- a/OptiTrack NMotive converter.csproj
+++ b/OptiTrack NMotive converter.csproj
@@ -10,4 +10,10 @@
         <HintPath>NMotive API\NMotive.dll</HintPath>
       </Reference>
   </ItemGroup>
+  <ItemGroup>
+    <ContentWithTargetPath Include="NMotive API\platforms\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <TargetPath>platforms\%(RecursiveDir)\%(Filename)%(Extension)</TargetPath>
+    </ContentWithTargetPath>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Added the csproj option to copy the qwindows.dll in the `bin/` folder to enable debugging and code distribution when building from source.